### PR TITLE
Add missing provider for .deb and .rpm

### DIFF
--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -10,4 +10,10 @@ end
 package 'wkhtmltopdf' do
   source download_dest
   not_if "/usr/local/bin/wkhtmltopdf --version | grep #{node['wkhtmltopdf-update']['version']}"
+
+  if source.end_with?('.deb')
+    provider Chef::Provider::Package::Dpkg
+  elsif source.end_with?('.rpm')
+    provider Chef::Provider::Package::Rpm
+  end
 end


### PR DESCRIPTION
`source` isn’t valid on `package` unless you specify a provider 
(See chef/chef#1763). This probably does not fix win nor osx.